### PR TITLE
Update Bootstrap

### DIFF
--- a/.htmlhintrc
+++ b/.htmlhintrc
@@ -9,6 +9,7 @@
   "button-type-require": true,
   "doctype-first": true,
   "doctype-html5": true,
+  "frame-title-require": true,
   "h1-require": true,
   "head-script-disabled": true,
   "head-style-disabled": true,

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
-lockfile-version = 3
 registry = 'https://registry.npmjs.org/'

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2023 Christian Oliff
+Copyright (c) Christian Oliff
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/dest/src/index.html
+++ b/dest/src/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Bootstrap 5 Migrate Tool Test Page</title>
     <meta name="description" content="Test HTML page for the Bootstrap 4 to Bootstrap 5 Migrate Tool Script" />
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2280%22>⚡</text></svg>" />
     <meta property="og:image" content="https://christianoliff.com/img/header/2024/header-bootstrap-5-migrate-tool.jpg" />
     <link rel="author" href="https://christianoliff.com/" />
@@ -714,7 +714,7 @@
       <hr class="my-5" />
 
       <p class="my-3 small">
-        &copy; 2023-2024 <a href="https://christianoliff.com/" target="_blank" rel="noopener" class="text-dark">Christian Oliff</a> /
+        &copy; 2023-2025 <a href="https://christianoliff.com/" target="_blank" rel="noopener" class="text-dark">Christian Oliff</a> /
         <a href="https://github.com/coliff/bootstrap-5-migrate-tool" target="_blank" rel="noopener" class="text-dark">GitHub</a>
       </p>
     </footer>
@@ -732,7 +732,7 @@
       src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.slim.min.js"
       integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
       crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"></script>
     <script>
       $(function () {
         $('[data-bs-toggle="popover"]').popover();

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -37,7 +37,7 @@ async function migrate(cb) {
           /<link href=["']https:\/\/cdnjs\.cloudflare\.com\/ajax\/libs\/bootstrap\/4\.\d+\.\d+\/dist\/css\/bootstrap(\.min)?\.css["'] rel=["']stylesheet["'] ?\/?>/g,
           function () {
             CDNLinksChanged++;
-            return '<link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.7/css/bootstrap.min.css" rel="stylesheet">';
+            return '<link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.8/css/bootstrap.min.css" rel="stylesheet">';
           }
         )
       )
@@ -45,77 +45,77 @@ async function migrate(cb) {
       .pipe(
         replace(/<link href=["']https:\/\/cdn\.jsdelivr\.net\/npm\/bootstrap@4\.\d+\.\d+\/dist\/css\/bootstrap(\.min)?\.css["'] rel=["']stylesheet["'] ?\/?>/g, function () {
           CDNLinksChanged++;
-          return '<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/css/bootstrap.min.css" rel="stylesheet">';
+          return '<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" rel="stylesheet">';
         })
       )
       // Stackpath CSS
       .pipe(
         replace(/<link href=["']https:\/\/stackpath\.bootstrapcdn\.com\/bootstrap\/4\.\d+\.\d+\/css\/bootstrap(\.min)?\.css["'] rel=["']stylesheet["'] ?\/?>/g, function () {
           CDNLinksChanged++;
-          return '<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/css/bootstrap.min.css">';
+          return '<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css">';
         })
       )
       // UNPKG CSS
       .pipe(
         replace(/<link href=["']https:\/\/unpkg\.com\/bootstrap\/4\.\d+\.\d+\/css\/bootstrap(\.min)?\.css["'] rel=["']stylesheet["'] ?\/?>/g, function () {
           CDNLinksChanged++;
-          return '<link href="https://unpkg.com/bootstrap@5.3.7/dist/css/bootstrap.min.css">';
+          return '<link href="https://unpkg.com/bootstrap@5.3.8/dist/css/bootstrap.min.css">';
         })
       )
       // CDNJS JS
       .pipe(
         replace(/<script src=["']https:\/\/cdn\.cloudflare\.com\/ajax\/libs\/bootstrap\/4\.\d+\.\d+\/dist\/js\/bootstrap(\.min)?\.js["']>/g, function () {
           CDNLinksChanged++;
-          return '<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.7/js/bootstrap.min.js">';
+          return '<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.8/js/bootstrap.min.js">';
         })
       )
       // JSDelivr JS
       .pipe(
         replace(/<script src=["']https:\/\/cdn\.jsdelivr\.net\/npm\/bootstrap@4\.\d+\.\d+\/dist\/js\/bootstrap(\.min)?\.js["']>/g, function () {
           CDNLinksChanged++;
-          return '<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/js/bootstrap.min.js">';
+          return '<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.min.js">';
         })
       )
       // Stackpath JS
       .pipe(
         replace(/<script src=["']https:\/\/stackpath\.bootstrapcdn\.com\/bootstrap\/4\.\d+\.\d+\/js\/bootstrap(\.min)?\.js["']>/g, function () {
           CDNLinksChanged++;
-          return '<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/js/bootstrap.min.js">';
+          return '<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.min.js">';
         })
       )
       // UNPKG JS
       .pipe(
         replace(/<script src=["']https:\/\/unpkg\.com\/bootstrap\/4\.\d+\.\d+\/js\/bootstrap(\.min)?\.js["']>/g, function () {
           CDNLinksChanged++;
-          return '<script src="https://unpkg.com/bootstrap@5.3.7/dist/js/bootstrap.min.js">';
+          return '<script src="https://unpkg.com/bootstrap@5.3.8/dist/js/bootstrap.min.js">';
         })
       )
       // CDNJS Bundle JS
       .pipe(
         replace(/<script src=["']https:\/\/cdn\.cloudflare\.com\/ajax\/libs\/bootstrap\/4\.\d+\.\d+\/dist\/js\/bootstrap\.bundle(\.min)?\.js["']>/g, function () {
           CDNLinksChanged++;
-          return '<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.7/js/bootstrap.bundle.min.js">';
+          return '<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.8/js/bootstrap.bundle.min.js">';
         })
       )
       // JSDelivr Bundle JS
       .pipe(
         replace(/<script src=["']https:\/\/cdn\.jsdelivr\.net\/npm\/bootstrap@4\.\d+\.\d+\/dist\/js\/bootstrap\.bundle(\.min)?\.js["']>/g, function () {
           CDNLinksChanged++;
-          return '<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/js/bootstrap.bundle.min.js">';
+          return '<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js">';
         })
       )
       // Stackpath Bundle JS
       .pipe(
         replace(/<script src=["']https:\/\/stackpath\.bootstrapcdn\.com\/bootstrap\/4\.\d+\.\d+\/js\/bootstrap\.bundle(\.min)?\.js["']>/g, function () {
           CDNLinksChanged++;
-          return '<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/js/bootstrap.bundle.min.js">';
+          return '<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js">';
         })
       )
       // UNPKG Bundle JS
       .pipe(
         replace(/<script src=["']https:\/\/unpkg\.com\/bootstrap\/4\.\d+\.\d+\/js\/bootstrap\.bundle(\.min)?\.js["']>/g, function () {
           CDNLinksChanged++;
-          return '<script src="https://unpkg.com/bootstrap@5.3.7/dist/js/bootstrap.bundle.min.js">';
+          return '<script src="https://unpkg.com/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js">';
         })
       )
       .pipe(

--- a/src/index.html
+++ b/src/index.html
@@ -714,7 +714,7 @@
       <hr class="my-5" />
 
       <p class="my-3 small">
-        &copy; 2023-2024 <a href="https://christianoliff.com/" target="_blank" rel="noopener" class="text-dark">Christian Oliff</a> /
+        &copy; 2023-2025 <a href="https://christianoliff.com/" target="_blank" rel="noopener" class="text-dark">Christian Oliff</a> /
         <a href="https://github.com/coliff/bootstrap-5-migrate-tool" target="_blank" rel="noopener" class="text-dark">GitHub</a>
       </p>
     </footer>


### PR DESCRIPTION
This pull request primarily updates Bootstrap CDN links to use the latest version (5.3.8) throughout the project, ensures copyright information is current, and makes minor configuration improvements.

**Dependency and CDN updates:**

* Updated all Bootstrap CDN links in `dest/src/index.html` and the migration logic in `gulpfile.js` to reference version 5.3.8 instead of 5.3.6/5.3.7, ensuring the project uses the latest Bootstrap release. [[1]](diffhunk://#diff-4c8082674e9a9470c12c4d6ba654e00493e34859a74e4e9e73af78adc432c4a1L8-R8) [[2]](diffhunk://#diff-4c8082674e9a9470c12c4d6ba654e00493e34859a74e4e9e73af78adc432c4a1L735-R735) [[3]](diffhunk://#diff-25789e3ba4c2adf4a68996260eb693a441b4a834c38b76167a120f0b51b969f7L40-R118)

**Copyright and licensing:**

* Updated copyright years from 2023-2024 to 2023-2025 in both `dest/src/index.html` and `src/index.html` for accuracy. [[1]](diffhunk://#diff-4c8082674e9a9470c12c4d6ba654e00493e34859a74e4e9e73af78adc432c4a1L717-R717) [[2]](diffhunk://#diff-ce434ef5cc161194b450135a3586eb89357fc270e8aaa8e336db5a04e8d52fbeL717-R717)
* Removed the year from the copyright statement in `LICENSE`.

**Configuration improvements:**

* Added the `frame-title-require` rule to `.htmlhintrc` for stricter HTML validation.
* Removed the `lockfile-version = 3` line from `.npmrc`, likely to avoid npm version conflicts.