### PR TITLE
Improve CDN regex

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,5 +4,6 @@ We are happy to accept contributions from the community to improve this project.
 
 ## Contribution Guidelines
 
-- Use an [EditorConfig](https://editorconfig.org) plugin for consistent spacing and code formatting
-- Run Prettier and ESLint before committing
+- Use an [EditorConfig](https://editorconfig.org) plugin for consistent spacing and code formatting.
+- Run Prettier and ESLint before committing.
+- Follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard for commit messages.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -34,7 +34,7 @@ async function migrate(cb) {
       // CDNJS CSS
       .pipe(
         replace(
-          /<link href=["']https:\/\/cdnjs\.cloudflare\.com\/ajax\/libs\/bootstrap\/4\.\d+\.\d+\/dist\/css\/bootstrap(\.min)?\.css["'] rel=["']stylesheet["'] ?\/?>/g,
+          /<link(?=\s)(?=(?:[^>]*\s+)?href=["']https:\/\/cdnjs\.cloudflare\.com\/ajax\/libs\/bootstrap\/4\.\d+\.\d+\/dist\/css\/bootstrap(\.min)?\.css["'])(?=(?:[^>]*\s+)?rel=["']stylesheet["'])[^>]*>/g,
           function () {
             CDNLinksChanged++;
             return '<link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.8/css/bootstrap.min.css" rel="stylesheet">';
@@ -43,23 +43,23 @@ async function migrate(cb) {
       )
       // JSDelivr CSS
       .pipe(
-        replace(/<link href=["']https:\/\/cdn\.jsdelivr\.net\/npm\/bootstrap@4\.\d+\.\d+\/dist\/css\/bootstrap(\.min)?\.css["'] rel=["']stylesheet["'] ?\/?>/g, function () {
+        replace(/<link(?=\s)(?=(?:[^>]*\s+)?href=["']https:\/\/cdn\.jsdelivr\.net\/npm\/bootstrap@4\.\d+\.\d+\/dist\/css\/bootstrap(\.min)?\.css["'])(?=(?:[^>]*\s+)?rel=["']stylesheet["'])[^>]*>/g, function () {
           CDNLinksChanged++;
           return '<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" rel="stylesheet">';
         })
       )
       // Stackpath CSS
       .pipe(
-        replace(/<link href=["']https:\/\/stackpath\.bootstrapcdn\.com\/bootstrap\/4\.\d+\.\d+\/css\/bootstrap(\.min)?\.css["'] rel=["']stylesheet["'] ?\/?>/g, function () {
+        replace(/<link(?=\s)(?=(?:[^>]*\s+)?href=["']https:\/\/stackpath\.bootstrapcdn\.com\/bootstrap\/4\.\d+\.\d+\/css\/bootstrap(\.min)?\.css["'])(?=(?:[^>]*\s+)?rel=["']stylesheet["'])[^>]*>/g, function () {
           CDNLinksChanged++;
-          return '<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css">';
+          return '<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" rel="stylesheet">';
         })
       )
       // UNPKG CSS
       .pipe(
-        replace(/<link href=["']https:\/\/unpkg\.com\/bootstrap\/4\.\d+\.\d+\/css\/bootstrap(\.min)?\.css["'] rel=["']stylesheet["'] ?\/?>/g, function () {
+        replace(/<link(?=\s)(?=(?:[^>]*\s+)?href=["']https:\/\/unpkg\.com\/bootstrap\/4\.\d+\.\d+\/css\/bootstrap(\.min)?\.css["'])(?=(?:[^>]*\s+)?rel=["']stylesheet["'])[^>]*>/g, function () {
           CDNLinksChanged++;
-          return '<link href="https://unpkg.com/bootstrap@5.3.8/dist/css/bootstrap.min.css">';
+          return '<link href="https://unpkg.com/bootstrap@5.3.8/dist/css/bootstrap.min.css" rel="stylesheet">';
         })
       )
       // CDNJS JS


### PR DESCRIPTION
This pull request updates the contribution guidelines and improves the migration script for updating Bootstrap CDN links. The migration script now uses more robust regular expressions to match and replace old Bootstrap 4 CSS links with Bootstrap 5 links across multiple CDNs, ensuring the `rel="stylesheet"` attribute is always present in the replacements.

**Contribution guidelines update:**

* Added a requirement to follow the Conventional Commits standard for commit messages in `.github/CONTRIBUTING.md`.

**Migration script improvements:**

* Updated regular expressions in `gulpfile.js` for CDNJS, JSDelivr, Stackpath, and UNPKG to more reliably match `<link>` tags with Bootstrap 4 CSS and replace them with Bootstrap 5 links, ensuring the `rel="stylesheet"` attribute is included. [[1]](diffhunk://#diff-25789e3ba4c2adf4a68996260eb693a441b4a834c38b76167a120f0b51b969f7L37-R37) [[2]](diffhunk://#diff-25789e3ba4c2adf4a68996260eb693a441b4a834c38b76167a120f0b51b969f7L46-R62)