### PR TITLE
Update workflows to use pinned action SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,9 @@ updates:
   - package-ecosystem: npm
     directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly
     versioning-strategy: increase
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,17 +19,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@f1f6e5f6af878fb37288ce1c627459e94dbf7d01 # v3.30.1
         with:
           languages: "javascript"
           queries: +security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@f1f6e5f6af878fb37288ce1c627459e94dbf7d01 # v3.30.1
         with:
           category: "/language:javascript"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,12 +16,12 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           registry-url: "https://registry.npmjs.org"
 

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -19,6 +19,6 @@ jobs:
     if: github.repository == 'coliff/bootstrap-5-migrate-tool'
 
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
-      - uses: actions/checkout@v5
-      - uses: streetsidesoftware/cspell-action@v7
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: streetsidesoftware/cspell-action@dcd03dc3e8a59ec2e360d0c62db517baa0b4bb6d # v7.2.0
         with:
           check_dot_files: false
           incremental_files_only: true

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -23,12 +23,12 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
 
       - name: Super-linter
-        uses: super-linter/super-linter/slim@v8
+        uses: super-linter/super-linter/slim@ffde3b2b33b745cb612d787f669ef9442b1339a6 # v8.1.0
         env:
           DEFAULT_BRANCH: main
           FILTER_REGEX_EXCLUDE: .*src/.*
@@ -42,7 +42,6 @@ jobs:
           VALIDATE_EDITORCONFIG: false
           VALIDATE_JAVASCRIPT_ES: false
           VALIDATE_JAVASCRIPT_PRETTIER: false
-          VALIDATE_JAVASCRIPT_STANDARD: false
           VALIDATE_JSON: false
           VALIDATE_JSON_PRETTIER: false
           VALIDATE_JSCPD: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,12 +27,12 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: ${{ matrix.node }}
           cache: npm

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/coliff/bootstrap-5-migrate-tool.git"
+    "url": "https://github.com/coliff/bootstrap-5-migrate-tool.git"
   },
   "funding": {
     "type": "github",


### PR DESCRIPTION
Pinned all GitHub Actions in workflow files to specific commit SHAs for improved security and reproducibility. Changed Dependabot update schedule from weekly to monthly. Also removed the 'VALIDATE_JAVASCRIPT_STANDARD' option from the super-linter workflow and updated the repository URL in package.json to remove the 'git+' prefix.